### PR TITLE
Low Memory POC Logging Backend

### DIFF
--- a/.github/workflows/code-coverage-test.yml
+++ b/.github/workflows/code-coverage-test.yml
@@ -109,6 +109,7 @@ jobs:
           gcov -abcfu pg_stat_monitor.c
           gcov -abcfu guc.c
           gcov -abcfu hash_query.c
+          gcov -abcfu json_export.c
           sudo chmod -R ugo+rwx *.gcov*
         working-directory: src/pg_stat_monitor
 
@@ -118,7 +119,7 @@ jobs:
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
           working-directory: ./src/pg_stat_monitor
-          files: ./pg_stat_monitor.c.gcov,./hash_query.c.gcov,./guc.c.gcov
+          files: ./pg_stat_monitor.c.gcov,./hash_query.c.gcov,./guc.c.gcov,./json_export.c.gcov
 
       - name: Change dir permissions on fail
         if: ${{ failure() }}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # contrib/pg_stat_monitor/Makefile
 
 MODULE_big = pg_stat_monitor
-OBJS = hash_query.o guc.o pg_stat_monitor.o $(WIN32RES)
+OBJS = hash_query.o guc.o pg_stat_monitor.o json_export.o $(WIN32RES)
 
 EXTENSION = pg_stat_monitor
 DATA = pg_stat_monitor--2.0.sql pg_stat_monitor--1.0--2.0.sql pg_stat_monitor--2.0--2.1.sql pg_stat_monitor--2.1--2.2.sql pg_stat_monitor--2.2--2.3.sql

--- a/guc.c
+++ b/guc.c
@@ -291,7 +291,7 @@ init_guc(void)
 	DefineCustomBoolVariable("pg_stat_monitor.pgsm_enable_json_log",	/* name */
 							 "Enable/Disable JSON logging of query statistics.",	/* short_desc */
 							 NULL,	/* long_desc */
-							 &pgsm_enable_json_log, /* value address */
+							 &pgsm_enable_json_log,	/* value address */
 							 false,	/* boot value */
 							 PGC_SUSET, /* context */
 							 0, /* flags */

--- a/guc.c
+++ b/guc.c
@@ -57,7 +57,7 @@ init_guc(void)
 							NULL,	/* long_desc */
 							&pgsm_max,	/* value address */
 							3,	/* boot value */
-							3, /* min value */
+							3,	/* min value */
 							10240,	/* max value */
 							PGC_POSTMASTER, /* context */
 							GUC_UNIT_MB,	/* flags */
@@ -84,7 +84,8 @@ init_guc(void)
 							"Sets the maximum number of buckets.",	/* short_desc */
 							NULL,	/* long_desc */
 							&pgsm_max_buckets,	/* value address */
-							2, /* boot value - reduced from 10 to 2 for low-memory fork */
+							2,	/* boot value - reduced from 10 to 2 for
+								 * low-memory fork */
 							1,	/* min value */
 							20000,	/* max value */
 							PGC_POSTMASTER, /* context */
@@ -154,7 +155,7 @@ init_guc(void)
 							"Sets the maximum size of shared memory in (MB) used for query tracked by pg_stat_monitor.",	/* short_desc */
 							NULL,	/* long_desc */
 							&pgsm_query_shared_buffer,	/* value address */
-							3, /* boot value */
+							3,	/* boot value */
 							3,	/* min value */
 							10000,	/* max value */
 							PGC_POSTMASTER, /* context */
@@ -288,12 +289,13 @@ init_guc(void)
 							 NULL	/* show_hook */
 		);
 
-	DefineCustomBoolVariable("pg_stat_monitor.pgsm_enable_json_log", /* name */
+	DefineCustomBoolVariable("pg_stat_monitor.pgsm_enable_json_log",	/* name */
 							 "Enable/Disable JSON logging of query statistics.",	/* short_desc */
 							 NULL,	/* long_desc */
-							 &pgsm_enable_json_log,	/* value address */
-							 true, /* boot value - enabled by default for automatic export */
-							 PGC_SUSET,	/* context */
+							 &pgsm_enable_json_log, /* value address */
+							 true,	/* boot value - enabled by default for
+									 * automatic export */
+							 PGC_SUSET, /* context */
 							 0, /* flags */
 							 NULL,	/* check_hook */
 							 NULL,	/* assign_hook */

--- a/guc.c
+++ b/guc.c
@@ -36,6 +36,7 @@ bool		pgsm_track_utility;
 bool		pgsm_track_application_names;
 bool		pgsm_enable_pgsm_query_id;
 int			pgsm_track;
+bool		pgsm_enable_json_log;
 static int	pgsm_overflow_target;	/* Not used since 2.0 */
 
 /* Check hooks to ensure histogram_min < histogram_max */
@@ -55,8 +56,8 @@ init_guc(void)
 							"Sets the maximum size of shared memory in (MB) used for statement's metadata tracked by pg_stat_monitor.", /* short_desc */
 							NULL,	/* long_desc */
 							&pgsm_max,	/* value address */
-							256,	/* boot value */
-							10, /* min value */
+							3,	/* boot value */
+							3, /* min value */
 							10240,	/* max value */
 							PGC_POSTMASTER, /* context */
 							GUC_UNIT_MB,	/* flags */
@@ -83,7 +84,7 @@ init_guc(void)
 							"Sets the maximum number of buckets.",	/* short_desc */
 							NULL,	/* long_desc */
 							&pgsm_max_buckets,	/* value address */
-							10, /* boot value */
+							2, /* boot value - reduced from 10 to 2 for low-memory fork */
 							1,	/* min value */
 							20000,	/* max value */
 							PGC_POSTMASTER, /* context */
@@ -149,12 +150,12 @@ init_guc(void)
 							NULL	/* show_hook */
 		);
 
-	DefineCustomIntVariable("pg_stat_monitor.pgsm_query_shared_buffer", /* name */
+	DefineCustomIntVariable("pg_stat_monitor.pgsm_kuery_shared_buffer", /* name */
 							"Sets the maximum size of shared memory in (MB) used for query tracked by pg_stat_monitor.",	/* short_desc */
 							NULL,	/* long_desc */
 							&pgsm_query_shared_buffer,	/* value address */
-							20, /* boot value */
-							1,	/* min value */
+							3, /* boot value */
+							3,	/* min value */
 							10000,	/* max value */
 							PGC_POSTMASTER, /* context */
 							GUC_UNIT_MB,	/* flags */
@@ -281,6 +282,18 @@ init_guc(void)
 							 &pgsm_track_planning,	/* value address */
 							 false, /* boot value */
 							 PGC_USERSET,	/* context */
+							 0, /* flags */
+							 NULL,	/* check_hook */
+							 NULL,	/* assign_hook */
+							 NULL	/* show_hook */
+		);
+
+	DefineCustomBoolVariable("pg_stat_monitor.pgsm_enable_json_log", /* name */
+							 "Enable/Disable JSON logging of query statistics.",	/* short_desc */
+							 NULL,	/* long_desc */
+							 &pgsm_enable_json_log,	/* value address */
+							 true, /* boot value - enabled by default for automatic export */
+							 PGC_SUSET,	/* context */
 							 0, /* flags */
 							 NULL,	/* check_hook */
 							 NULL,	/* assign_hook */

--- a/guc.c
+++ b/guc.c
@@ -56,7 +56,7 @@ init_guc(void)
 							"Sets the maximum size of shared memory in (MB) used for statement's metadata tracked by pg_stat_monitor.", /* short_desc */
 							NULL,	/* long_desc */
 							&pgsm_max,	/* value address */
-							3,	/* boot value */
+							256,	/* boot value */
 							3,	/* min value */
 							10240,	/* max value */
 							PGC_POSTMASTER, /* context */
@@ -84,8 +84,7 @@ init_guc(void)
 							"Sets the maximum number of buckets.",	/* short_desc */
 							NULL,	/* long_desc */
 							&pgsm_max_buckets,	/* value address */
-							2,	/* boot value - reduced from 10 to 2 for
-								 * low-memory fork */
+							10,	/* boot value */
 							1,	/* min value */
 							20000,	/* max value */
 							PGC_POSTMASTER, /* context */
@@ -151,11 +150,11 @@ init_guc(void)
 							NULL	/* show_hook */
 		);
 
-	DefineCustomIntVariable("pg_stat_monitor.pgsm_kuery_shared_buffer", /* name */
+	DefineCustomIntVariable("pg_stat_monitor.pgsm_query_shared_buffer", /* name */
 							"Sets the maximum size of shared memory in (MB) used for query tracked by pg_stat_monitor.",	/* short_desc */
 							NULL,	/* long_desc */
 							&pgsm_query_shared_buffer,	/* value address */
-							3,	/* boot value */
+							20,	/* boot value */
 							3,	/* min value */
 							10000,	/* max value */
 							PGC_POSTMASTER, /* context */
@@ -293,8 +292,7 @@ init_guc(void)
 							 "Enable/Disable JSON logging of query statistics.",	/* short_desc */
 							 NULL,	/* long_desc */
 							 &pgsm_enable_json_log, /* value address */
-							 true,	/* boot value - enabled by default for
-									 * automatic export */
+							 false,	/* boot value */
 							 PGC_SUSET, /* context */
 							 0, /* flags */
 							 NULL,	/* check_hook */

--- a/guc.c
+++ b/guc.c
@@ -84,7 +84,7 @@ init_guc(void)
 							"Sets the maximum number of buckets.",	/* short_desc */
 							NULL,	/* long_desc */
 							&pgsm_max_buckets,	/* value address */
-							10,	/* boot value */
+							10, /* boot value */
 							1,	/* min value */
 							20000,	/* max value */
 							PGC_POSTMASTER, /* context */
@@ -154,8 +154,8 @@ init_guc(void)
 							"Sets the maximum size of shared memory in (MB) used for query tracked by pg_stat_monitor.",	/* short_desc */
 							NULL,	/* long_desc */
 							&pgsm_query_shared_buffer,	/* value address */
-							20,	/* boot value */
-							3,	/* min value */
+							20, /* boot value */
+							1,	/* min value */
 							10000,	/* max value */
 							PGC_POSTMASTER, /* context */
 							GUC_UNIT_MB,	/* flags */

--- a/json_export.c
+++ b/json_export.c
@@ -1,0 +1,163 @@
+/*-------------------------------------------------------------------------
+ *
+ * json_export.c
+ *	  JSON export functionality for pg_stat_monitor bucket data
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+#include <sys/time.h>
+#include "utils/builtins.h"
+#include "utils/inet.h"
+#include "lib/stringinfo.h"
+#include "executor/spi.h"
+#include "utils/memutils.h"
+#include "json_export.h"
+#include "pg_stat_monitor.h"
+
+
+/*
+ * Log bucket data as JSON to PostgreSQL log - one log entry per query for scalability
+ */
+void
+pgsm_log_bucket_json(uint64 bucket_id)
+{
+	StringInfoData json;
+	int	ret;
+	MemoryContext old_context;
+	struct timeval start_time, end_time;
+	double duration_seconds;
+	time_t rotation_timestamp;
+	int query_count = 0;
+
+	if (!pgsm_enable_json_log)
+		return;
+
+	/* Record start time and timestamp for duration calculation */
+	gettimeofday(&start_time, NULL);
+	rotation_timestamp = time(NULL);
+
+	/* Initialize JSON output buffer */
+	initStringInfo(&json);
+
+	/* Try to execute a SQL query to get the bucket data */
+	old_context = CurrentMemoryContext;
+
+	PG_TRY();
+	{
+		/* Start a transaction for SQL execution */
+		if (SPI_connect() != SPI_OK_CONNECT)
+		{
+			/* Failed to connect - likely in background context */
+			gettimeofday(&end_time, NULL);
+			duration_seconds = (end_time.tv_sec - start_time.tv_sec) +
+							  (end_time.tv_usec - start_time.tv_usec) / 1000000.0;
+			elog(LOG, "[pg_stat_monitor] JSON export: {\"event\": \"bucket_rotation_error\", \"bucket_id\": %lu, \"timestamp\": %ld, \"duration_seconds\": %.3f, \"note\": \"SPI connection failed - background context\"}",
+				 bucket_id, rotation_timestamp, duration_seconds);
+			pfree(json.data);
+			return;
+		}
+
+		/* First get count of queries in this bucket */
+		appendStringInfo(&json, "SELECT COUNT(*) FROM pg_stat_monitor WHERE bucket = %lu", bucket_id);
+		ret = SPI_execute(json.data, true, 0);
+
+		if (ret == SPI_OK_SELECT && SPI_processed > 0)
+		{
+			bool isnull;
+			Datum count_datum = SPI_getbinval(SPI_tuptable->vals[0], SPI_tuptable->tupdesc, 1, &isnull);
+			if (!isnull)
+				query_count = DatumGetInt32(count_datum);
+		}
+
+		/* Log bucket rotation start with metadata */
+		elog(LOG, "[pg_stat_monitor] JSON export: {\"event\": \"bucket_rotation_start\", \"bucket_id\": %lu, \"timestamp\": %ld, \"query_count\": %d}",
+			 bucket_id, rotation_timestamp, query_count);
+
+		if (query_count > 0)
+		{
+			/* Reset and build query to get individual query records */
+			resetStringInfo(&json);
+			appendStringInfo(&json,
+				"SELECT row_to_json(t) FROM ("
+				"SELECT bucket, bucket_start_time, userid, username, dbid, datname, "
+				"client_ip, pgsm_query_id, queryid, toplevel, top_queryid, query, "
+				"comments, planid, query_plan, top_query, application_name, relations, "
+				"cmd_type, cmd_type_text, elevel, sqlcode, message, calls, "
+				"total_exec_time, min_exec_time, max_exec_time, mean_exec_time, "
+				"stddev_exec_time, rows, shared_blks_hit, shared_blks_read, "
+				"shared_blks_dirtied, shared_blks_written, local_blks_hit, "
+				"local_blks_read, local_blks_dirtied, local_blks_written, "
+				"temp_blks_read, temp_blks_written, shared_blk_read_time, "
+				"shared_blk_write_time, local_blk_read_time, local_blk_write_time, "
+				"temp_blk_read_time, temp_blk_write_time, resp_calls, cpu_user_time, "
+				"cpu_sys_time, wal_records, wal_fpi, wal_bytes, bucket_done, plans, "
+				"total_plan_time, min_plan_time, max_plan_time, mean_plan_time, "
+				"stddev_plan_time, jit_functions, jit_generation_time, "
+				"jit_inlining_count, jit_inlining_time, jit_optimization_count, "
+				"jit_optimization_time, jit_emission_count, jit_emission_time "
+				"FROM pg_stat_monitor WHERE bucket = %lu"
+				") t",
+				bucket_id);
+
+			ret = SPI_execute(json.data, true, 0);
+
+			if (ret == SPI_OK_SELECT && SPI_processed > 0)
+			{
+				/* Log each query as a separate JSON entry */
+				for (uint64 i = 0; i < SPI_processed; i++)
+				{
+					bool isnull;
+					Datum result_datum = SPI_getbinval(SPI_tuptable->vals[i], SPI_tuptable->tupdesc, 1, &isnull);
+
+					if (!isnull)
+					{
+						StringInfoData log_msg;
+						char *query_json = TextDatumGetCString(result_datum);
+
+						/* Build log message safely without format string issues */
+						initStringInfo(&log_msg);
+						appendStringInfo(&log_msg,
+							"[pg_stat_monitor] JSON export: {\"event\": \"bucket_query\", \"bucket_id\": %lu, \"timestamp\": %ld, \"query_index\": %lu, \"query_count\": %d, \"query\": ",
+							bucket_id, rotation_timestamp, i + 1, query_count);
+						appendStringInfoString(&log_msg, query_json);
+						appendStringInfoChar(&log_msg, '}');
+
+						ereport(LOG, (errmsg_internal("%s", log_msg.data)));
+
+						pfree(log_msg.data);
+						if (query_json)
+							pfree(query_json);
+					}
+				}
+			}
+		}
+
+		/* Calculate final duration and log bucket rotation end */
+		gettimeofday(&end_time, NULL);
+		duration_seconds = (end_time.tv_sec - start_time.tv_sec) +
+						  (end_time.tv_usec - start_time.tv_usec) / 1000000.0;
+
+		elog(LOG, "[pg_stat_monitor] JSON export: {\"event\": \"bucket_rotation_end\", \"bucket_id\": %lu, \"timestamp\": %ld, \"duration_seconds\": %.3f, \"queries_exported\": %d}",
+			 bucket_id, rotation_timestamp, duration_seconds, query_count);
+
+		SPI_finish();
+	}
+	PG_CATCH();
+	{
+		MemoryContextSwitchTo(old_context);
+
+		/* SPI calls can fail in background processes, fall back to simple logging */
+		gettimeofday(&end_time, NULL);
+		duration_seconds = (end_time.tv_sec - start_time.tv_sec) +
+						  (end_time.tv_usec - start_time.tv_usec) / 1000000.0;
+		elog(LOG, "[pg_stat_monitor] JSON export: {\"event\": \"bucket_rotation_error\", \"bucket_id\": %lu, \"timestamp\": %ld, \"duration_seconds\": %.3f, \"note\": \"Export failed - not available in background context\"}",
+			 bucket_id, rotation_timestamp, duration_seconds);
+
+		FlushErrorState();
+	}
+	PG_END_TRY();
+
+	pfree(json.data);
+}

--- a/json_export.c
+++ b/json_export.c
@@ -16,72 +16,130 @@
  */
 
 #include "postgres.h"
+
+#include <math.h>
 #include <sys/time.h>
-#include "utils/builtins.h"
+
 #include "lib/stringinfo.h"
+#include "utils/builtins.h"
 #include "utils/timestamp.h"
+
 #include "json_export.h"
 #include "pg_stat_monitor.h"
 
 /* Helper function to escape strings for JSON output */
-static void
-escape_json(StringInfo buf, const char *str)
-{
+static void escape_json(StringInfo buf, const char *str) {
 	const char *p;
 
 	appendStringInfoChar(buf, '"');
-	for (p = str; *p; p++)
-	{
-		switch (*p)
-		{
-			case '"':
-				appendStringInfoString(buf, "\\\"");
-				break;
-			case '\\':
-				appendStringInfoString(buf, "\\\\");
-				break;
-			case '\b':
-				appendStringInfoString(buf, "\\b");
-				break;
-			case '\f':
-				appendStringInfoString(buf, "\\f");
-				break;
-			case '\n':
-				appendStringInfoString(buf, "\\n");
-				break;
-			case '\r':
-				appendStringInfoString(buf, "\\r");
-				break;
-			case '\t':
-				appendStringInfoString(buf, "\\t");
-				break;
-			default:
-				if ((unsigned char) *p < 0x20)
-					appendStringInfo(buf, "\\u%04x", (unsigned char) *p);
-				else
-					appendStringInfoChar(buf, *p);
-				break;
+	for (p = str; *p; p++) {
+		switch (*p) {
+		case '"':
+			appendStringInfoString(buf, "\\\"");
+			break;
+		case '\\':
+			appendStringInfoString(buf, "\\\\");
+			break;
+		case '\b':
+			appendStringInfoString(buf, "\\b");
+			break;
+		case '\f':
+			appendStringInfoString(buf, "\\f");
+			break;
+		case '\n':
+			appendStringInfoString(buf, "\\n");
+			break;
+		case '\r':
+			appendStringInfoString(buf, "\\r");
+			break;
+		case '\t':
+			appendStringInfoString(buf, "\\t");
+			break;
+		default:
+			if ((unsigned char)*p < 0x20)
+				appendStringInfo(buf, "\\u%04x", (unsigned char)*p);
+			else
+				appendStringInfoChar(buf, *p);
+			break;
 		}
 	}
 	appendStringInfoChar(buf, '"');
 }
 
+/* Helper function to add a JSON string field with null handling */
+static void add_json_string(StringInfo buf, const char *field_name,
+                            const char *value, bool add_comma) {
+	appendStringInfo(buf, "\"%s\":", field_name);
+	if (value && value[0])
+		escape_json(buf, value);
+	else
+		appendStringInfoString(buf, "null");
+
+	if (add_comma)
+		appendStringInfoString(buf, ",");
+}
+
+/* Helper function to convert client IP from integer to dotted decimal */
+static void format_client_ip(StringInfo buf, uint32 ip) {
+	if (ip == 0) {
+		appendStringInfoString(buf, "null");
+	} else {
+		appendStringInfo(buf, "\"%u.%u.%u.%u\"", (ip >> 24) & 0xFF,
+		                 (ip >> 16) & 0xFF, (ip >> 8) & 0xFF, ip & 0xFF);
+	}
+}
+
+/* Helper function to format relations array */
+static void format_relations(StringInfo buf, QueryInfo *info) {
+	int i;
+
+	appendStringInfoString(buf, "[");
+	for (i = 0; i < info->num_relations && i < REL_LST; i++) {
+		if (i > 0)
+			appendStringInfoString(buf, ",");
+		if (info->relations[i][0])
+			escape_json(buf, info->relations[i]);
+		else
+			appendStringInfoString(buf, "null");
+	}
+	appendStringInfoString(buf, "]");
+}
+
+/* Helper function to format histogram/response calls array */
+static void format_resp_calls(StringInfo buf, int *resp_calls) {
+	int i;
+
+	appendStringInfoString(buf, "[");
+	for (i = 0; i < MAX_RESPONSE_BUCKET; i++) {
+		if (i > 0)
+			appendStringInfoString(buf, ",");
+		appendStringInfo(buf, "%d", resp_calls[i]);
+	}
+	appendStringInfoString(buf, "]");
+}
+
+/* Helper to calculate standard deviation from sum of variances */
+static double calculate_stddev_time(double sum_var_time, int64 calls) {
+	if (calls <= 1)
+		return 0.0;
+	return sqrt(sum_var_time / (calls - 1));
+}
+
 /*
- * Log bucket data as JSON to PostgreSQL log - one log entry per query for scalability
+ * Log bucket data as JSON to PostgreSQL log - one log entry per query for
+ * scalability Includes all fields from the SQL view with proper type handling
+ * and null safety
  */
-void
-pgsm_log_bucket_json(uint64 bucket_id)
-{
+void pgsm_log_bucket_json(uint64 bucket_id) {
 	pgsmSharedState *pgsm;
 	PGSM_HASH_SEQ_STATUS hstat;
-	pgsmEntry  *entry;
-	struct timeval start_time,
-				end_time;
-	double		duration_seconds;
-	time_t		rotation_timestamp;
-	int			query_count = 0;
-	int			queries_exported = 0;
-	dsa_area   *query_dsa_area = NULL;
+	pgsmEntry *entry;
+	struct timeval start_time, end_time;
+	double duration_seconds;
+	time_t rotation_timestamp;
+	int query_count = 0;
+	int queries_exported = 0;
+	dsa_area *query_dsa_area = NULL;
 
 	if (!pgsm_enable_json_log)
 		return;
@@ -96,147 +154,278 @@ pgsm_log_bucket_json(uint64 bucket_id)
 
 	/* First pass: count queries in this bucket */
 	pgsm_hash_seq_init(&hstat, get_pgsmHash(), true);
-	while ((entry = pgsm_hash_seq_next(&hstat)) != NULL)
-	{
+	while ((entry = pgsm_hash_seq_next(&hstat)) != NULL) {
 		if (entry->key.bucket_id == bucket_id)
 			query_count++;
 	}
 	pgsm_hash_seq_term(&hstat);
 
 	/* Log bucket rotation start with metadata */
-	elog(LOG, "[pg_stat_monitor] JSON export: {\"event\": \"bucket_rotation_start\", \"bucket_id\": %lu, \"timestamp\": %ld, \"query_count\": %d}",
-		 bucket_id, rotation_timestamp, query_count);
+	elog(
+	    LOG,
+	    "[pg_stat_monitor] JSON export: {\"event\": \"bucket_rotation_start\", "
+	    "\"bucket_id\": %lu, \"timestamp\": %ld, \"query_count\": %d}",
+	    bucket_id, rotation_timestamp, query_count);
 
-	if (query_count > 0)
-	{
-		/* Second pass: export each query as JSON */
+	if (query_count > 0) {
+		/* Second pass: export each query as comprehensive JSON */
 		pgsm_hash_seq_init(&hstat, get_pgsmHash(), true);
-		while ((entry = pgsm_hash_seq_next(&hstat)) != NULL)
-		{
-			if (entry->key.bucket_id == bucket_id)
-			{
+		while ((entry = pgsm_hash_seq_next(&hstat)) != NULL) {
+			if (entry->key.bucket_id == bucket_id) {
 				StringInfoData json;
-				char	   *query_text = NULL;
-				char	   *username;
-				char	   *datname;
+				char *query_text = NULL;
+				char *top_query_text = NULL;
+				char *plan_text = NULL;
 				TimestampTz bucket_start_time = 0;
+				double stddev_exec_time;
+				double stddev_plan_time;
+				bool bucket_done;
 
 				queries_exported++;
 
 				/* Get query text from DSA or local pointer */
-				if (DsaPointerIsValid(entry->query_text.query_pos) && query_dsa_area)
-				{
-					char	   *query_ptr = dsa_get_address(query_dsa_area, entry->query_text.query_pos);
-
+				if (DsaPointerIsValid(entry->query_text.query_pos) &&
+				    query_dsa_area) {
+					char *query_ptr = dsa_get_address(
+					    query_dsa_area, entry->query_text.query_pos);
 					query_text = pstrdup(query_ptr);
-				}
-				else if (entry->query_text.query_pointer)
-				{
+				} else if (entry->query_text.query_pointer) {
 					query_text = pstrdup(entry->query_text.query_pointer);
 				}
-				else
-				{
-					query_text = pstrdup("Query text not available");
-				}
+
+				/* Get top query text - currently same as query text in most
+				 * cases */
+				top_query_text = query_text;
+
+				/* Get plan text if available */
+				if (entry->counters.planinfo.plan_len > 0)
+					plan_text = entry->counters.planinfo.plan_text;
 
 				/* Get bucket start time if available */
 				if (bucket_id < pgsm_max_buckets)
 					bucket_start_time = pgsm->bucket_start_time[bucket_id];
 
-				/* Get username and database name */
-				username = entry->username[0] ? entry->username : "unknown";
-				datname = entry->datname[0] ? entry->datname : "unknown";
+				/* Calculate derived values */
+				stddev_exec_time =
+				    calculate_stddev_time(entry->counters.time.sum_var_time,
+				                          entry->counters.calls.calls);
+				stddev_plan_time =
+				    calculate_stddev_time(entry->counters.plantime.sum_var_time,
+				                          entry->counters.plancalls.calls);
+				bucket_done =
+				    (bucket_id != pg_atomic_read_u64(&pgsm->current_wbucket));
 
-				/* Build JSON for this query */
+				/* Build comprehensive JSON using single template - FLATTENED
+				 * structure */
 				initStringInfo(&json);
 				appendStringInfo(&json,
-								 "[pg_stat_monitor] JSON export: {\"event\": \"bucket_query\", "
-								 "\"bucket_id\": %lu, "
-								 "\"timestamp\": %ld, "
-								 "\"query_index\": %d, "
-								 "\"query_count\": %d, "
-								 "\"query\": {",
-								 bucket_id, rotation_timestamp, queries_exported, query_count);
+				                 "[pg_stat_monitor] JSON export: {"
+				                 "\"event\":\"bucket_query\","
+				                 "\"bucket_id\":%lu,"
+				                 "\"timestamp\":%ld,"
+				                 "\"query_index\":%d,"
+				                 "\"query_count\":%d,"
 
-				/* Basic identification fields */
+				                 /* Basic identification */
+				                 "\"bucket\":%lu,"
+				                 "\"bucket_start_time\":%ld,"
+				                 "\"userid\":%u,",
+				                 bucket_id, rotation_timestamp,
+				                 queries_exported, query_count,
+				                 entry->key.bucket_id, (long)bucket_start_time,
+				                 entry->key.userid);
+
+				/* Handle username with proper escaping */
+				add_json_string(&json, "username",
+				                entry->username[0] ? entry->username : NULL,
+				                true);
+
+				appendStringInfo(&json, "\"dbid\":%u,", entry->key.dbid);
+
+				/* Handle datname with proper escaping */
+				add_json_string(&json, "datname",
+				                entry->datname[0] ? entry->datname : NULL,
+				                true);
+
+				appendStringInfoString(&json, "\"client_ip\":");
+				format_client_ip(&json, entry->key.ip);
+
+				/* Query identification fields */
+				appendStringInfo(
+				    &json,
+				    ",\"pgsm_query_id\":%lu,"
+				    "\"queryid\":%lu,"
+				    "\"planid\":%lu,"
+				    "\"top_queryid\":%lu,"
+				    "\"toplevel\":%s,",
+				    entry->pgsm_query_id, entry->key.queryid, entry->key.planid,
+				    entry->key
+				        .queryid, /* top_queryid is typically same as queryid */
+				    "true" /* toplevel - we don't track nested calls in current
+				              implementation */
+				);
+
+				/* Query texts */
+				appendStringInfoString(&json, "\"query\":");
+				if (query_text)
+					escape_json(&json, query_text);
+				else
+					appendStringInfoString(&json, "null");
+
+				add_json_string(&json, "query_plan", plan_text, true);
+				add_json_string(&json, "top_query", top_query_text, true);
+				add_json_string(&json, "application_name",
+				                entry->counters.info.application_name[0]
+				                    ? entry->counters.info.application_name
+				                    : NULL,
+				                true);
+				add_json_string(&json, "comments",
+				                entry->counters.info.comments[0]
+				                    ? entry->counters.info.comments
+				                    : NULL,
+				                true);
+
+				/* Relations array */
+				appendStringInfoString(&json, "\"relations\":");
+				format_relations(&json, &entry->counters.info);
+
+				/* Command type and error info */
 				appendStringInfo(&json,
-								 "\"bucket\": %lu, "
-								 "\"bucket_start_time\": %ld, "
-								 "\"userid\": %u, "
-								 "\"username\": \"%s\", "
-								 "\"dbid\": %u, "
-								 "\"datname\": \"%s\", "
-								 "\"queryid\": %lu, "
-								 "\"pgsm_query_id\": %lu, ",
-								 entry->key.bucket_id,
-								 (long) bucket_start_time,
-								 entry->key.userid,
-								 username,
-								 entry->key.dbid,
-								 datname,
-								 entry->key.queryid,
-								 entry->pgsm_query_id);
+				                 ",\"cmd_type\":%d,"
+				                 "\"elevel\":%ld,",
+				                 (int)entry->counters.info.cmd_type,
+				                 entry->counters.error.elevel);
 
-				/* Query text - needs special escaping */
-				appendStringInfo(&json, "\"query\": ");
-				escape_json(&json, query_text);
-				appendStringInfo(&json, ", ");
-
-				/* Command type */
-				appendStringInfo(&json,
-								 "\"cmd_type\": %d, ",
-								 entry->counters.info.cmd_type);
+				add_json_string(&json, "sqlcode",
+				                entry->counters.error.sqlcode[0]
+				                    ? entry->counters.error.sqlcode
+				                    : NULL,
+				                true);
+				add_json_string(&json, "message",
+				                entry->counters.error.message[0]
+				                    ? entry->counters.error.message
+				                    : NULL,
+				                true);
 
 				/* Execution statistics */
 				appendStringInfo(&json,
-								 "\"calls\": %ld, "
-								 "\"total_exec_time\": %.3f, "
-								 "\"min_exec_time\": %.3f, "
-								 "\"max_exec_time\": %.3f, "
-								 "\"mean_exec_time\": %.3f, "
-								 "\"rows\": %ld, ",
-								 entry->counters.calls.calls,
-								 entry->counters.time.total_time,
-								 entry->counters.time.min_time,
-								 entry->counters.time.max_time,
-								 entry->counters.time.mean_time,
-								 entry->counters.calls.rows);
+				                 "\"calls\":%ld,"
+				                 "\"total_exec_time\":%.3f,"
+				                 "\"min_exec_time\":%.3f,"
+				                 "\"max_exec_time\":%.3f,"
+				                 "\"mean_exec_time\":%.3f,"
+				                 "\"stddev_exec_time\":%.3f,"
+				                 "\"rows\":%ld,",
+				                 entry->counters.calls.calls,
+				                 entry->counters.time.total_time,
+				                 entry->counters.time.min_time,
+				                 entry->counters.time.max_time,
+				                 entry->counters.time.mean_time,
+				                 stddev_exec_time, entry->counters.calls.rows);
+
+				/* Planning statistics */
+				appendStringInfo(&json,
+				                 "\"plans\":%ld,"
+				                 "\"total_plan_time\":%.3f,"
+				                 "\"min_plan_time\":%.3f,"
+				                 "\"max_plan_time\":%.3f,"
+				                 "\"mean_plan_time\":%.3f,"
+				                 "\"stddev_plan_time\":%.3f,",
+				                 entry->counters.plancalls.calls,
+				                 entry->counters.plantime.total_time,
+				                 entry->counters.plantime.min_time,
+				                 entry->counters.plantime.max_time,
+				                 entry->counters.plantime.mean_time,
+				                 stddev_plan_time);
 
 				/* Block I/O statistics */
 				appendStringInfo(&json,
-								 "\"shared_blks_hit\": %ld, "
-								 "\"shared_blks_read\": %ld, "
-								 "\"shared_blks_dirtied\": %ld, "
-								 "\"shared_blks_written\": %ld, "
-								 "\"local_blks_hit\": %ld, "
-								 "\"local_blks_read\": %ld, "
-								 "\"local_blks_dirtied\": %ld, "
-								 "\"local_blks_written\": %ld, "
-								 "\"temp_blks_read\": %ld, "
-								 "\"temp_blks_written\": %ld, ",
-								 entry->counters.blocks.shared_blks_hit,
-								 entry->counters.blocks.shared_blks_read,
-								 entry->counters.blocks.shared_blks_dirtied,
-								 entry->counters.blocks.shared_blks_written,
-								 entry->counters.blocks.local_blks_hit,
-								 entry->counters.blocks.local_blks_read,
-								 entry->counters.blocks.local_blks_dirtied,
-								 entry->counters.blocks.local_blks_written,
-								 entry->counters.blocks.temp_blks_read,
-								 entry->counters.blocks.temp_blks_written);
+				                 "\"shared_blks_hit\":%ld,"
+				                 "\"shared_blks_read\":%ld,"
+				                 "\"shared_blks_dirtied\":%ld,"
+				                 "\"shared_blks_written\":%ld,"
+				                 "\"local_blks_hit\":%ld,"
+				                 "\"local_blks_read\":%ld,"
+				                 "\"local_blks_dirtied\":%ld,"
+				                 "\"local_blks_written\":%ld,"
+				                 "\"temp_blks_read\":%ld,"
+				                 "\"temp_blks_written\":%ld,"
+				                 "\"shared_blk_read_time\":%.3f,"
+				                 "\"shared_blk_write_time\":%.3f,"
+				                 "\"local_blk_read_time\":%.3f,"
+				                 "\"local_blk_write_time\":%.3f,"
+				                 "\"temp_blk_read_time\":%.3f,"
+				                 "\"temp_blk_write_time\":%.3f,",
+				                 entry->counters.blocks.shared_blks_hit,
+				                 entry->counters.blocks.shared_blks_read,
+				                 entry->counters.blocks.shared_blks_dirtied,
+				                 entry->counters.blocks.shared_blks_written,
+				                 entry->counters.blocks.local_blks_hit,
+				                 entry->counters.blocks.local_blks_read,
+				                 entry->counters.blocks.local_blks_dirtied,
+				                 entry->counters.blocks.local_blks_written,
+				                 entry->counters.blocks.temp_blks_read,
+				                 entry->counters.blocks.temp_blks_written,
+				                 entry->counters.blocks.shared_blk_read_time,
+				                 entry->counters.blocks.shared_blk_write_time,
+				                 entry->counters.blocks.local_blk_read_time,
+				                 entry->counters.blocks.local_blk_write_time,
+				                 entry->counters.blocks.temp_blk_read_time,
+				                 entry->counters.blocks.temp_blk_write_time);
+
+				/* Response calls histogram */
+				appendStringInfoString(&json, "\"resp_calls\":");
+				format_resp_calls(&json, entry->counters.resp_calls);
+
+				/* System info */
+				appendStringInfo(&json,
+				                 ",\"cpu_user_time\":%.3f,"
+				                 "\"cpu_sys_time\":%.3f,",
+				                 entry->counters.sysinfo.utime,
+				                 entry->counters.sysinfo.stime);
 
 				/* WAL usage */
 				appendStringInfo(&json,
-								 "\"wal_records\": %ld, "
-								 "\"wal_fpi\": %ld, "
-								 "\"wal_bytes\": %lu",
-								 entry->counters.walusage.wal_records,
-								 entry->counters.walusage.wal_fpi,
-								 entry->counters.walusage.wal_bytes);
+				                 "\"wal_records\":%ld,"
+				                 "\"wal_fpi\":%ld,"
+				                 "\"wal_bytes\":%lu,",
+				                 entry->counters.walusage.wal_records,
+				                 entry->counters.walusage.wal_fpi,
+				                 entry->counters.walusage.wal_bytes);
 
-				appendStringInfoString(&json, "}}");
+				/* JIT statistics */
+				appendStringInfo(&json,
+				                 "\"jit_functions\":%ld,"
+				                 "\"jit_generation_time\":%.3f,"
+				                 "\"jit_inlining_count\":%ld,"
+				                 "\"jit_inlining_time\":%.3f,"
+				                 "\"jit_optimization_count\":%ld,"
+				                 "\"jit_optimization_time\":%.3f,"
+				                 "\"jit_emission_count\":%ld,"
+				                 "\"jit_emission_time\":%.3f,"
+				                 "\"jit_deform_count\":%ld,"
+				                 "\"jit_deform_time\":%.3f,",
+				                 entry->counters.jitinfo.jit_functions,
+				                 entry->counters.jitinfo.jit_generation_time,
+				                 entry->counters.jitinfo.jit_inlining_count,
+				                 entry->counters.jitinfo.jit_inlining_time,
+				                 entry->counters.jitinfo.jit_optimization_count,
+				                 entry->counters.jitinfo.jit_optimization_time,
+				                 entry->counters.jitinfo.jit_emission_count,
+				                 entry->counters.jitinfo.jit_emission_time,
+				                 entry->counters.jitinfo.jit_deform_count,
+				                 entry->counters.jitinfo.jit_deform_time);
 
-				/* Log this query */
+				/* Timestamps and bucket status */
+				appendStringInfo(&json,
+				                 "\"stats_since\":%ld,"
+				                 "\"minmax_stats_since\":%ld,"
+				                 "\"bucket_done\":%s}",
+				                 (long)entry->stats_since,
+				                 (long)entry->minmax_stats_since,
+				                 bucket_done ? "true" : "false");
+
+				/* Log this comprehensive query record */
 				ereport(LOG, (errmsg_internal("%s", json.data)));
 
 				pfree(json.data);
@@ -250,8 +439,11 @@ pgsm_log_bucket_json(uint64 bucket_id)
 	/* Calculate final duration and log bucket rotation end */
 	gettimeofday(&end_time, NULL);
 	duration_seconds = (end_time.tv_sec - start_time.tv_sec) +
-		(end_time.tv_usec - start_time.tv_usec) / 1000000.0;
+	                   (end_time.tv_usec - start_time.tv_usec) / 1000000.0;
 
-	elog(LOG, "[pg_stat_monitor] JSON export: {\"event\": \"bucket_rotation_end\", \"bucket_id\": %lu, \"timestamp\": %ld, \"duration_seconds\": %.3f, \"queries_exported\": %d}",
-		 bucket_id, rotation_timestamp, duration_seconds, queries_exported);
+	elog(LOG,
+	     "[pg_stat_monitor] JSON export: {\"event\": \"bucket_rotation_end\", "
+	     "\"bucket_id\": %lu, \"timestamp\": %ld, \"duration_seconds\": %.3f, "
+	     "\"queries_exported\": %d}",
+	     bucket_id, rotation_timestamp, duration_seconds, queries_exported);
 }

--- a/json_export.c
+++ b/json_export.c
@@ -18,13 +18,53 @@
 #include "postgres.h"
 #include <sys/time.h>
 #include "utils/builtins.h"
-#include "utils/inet.h"
 #include "lib/stringinfo.h"
-#include "executor/spi.h"
-#include "utils/memutils.h"
+#include "utils/timestamp.h"
 #include "json_export.h"
 #include "pg_stat_monitor.h"
 
+/* Helper function to escape strings for JSON output */
+static void
+escape_json(StringInfo buf, const char *str)
+{
+	const char *p;
+
+	appendStringInfoChar(buf, '"');
+	for (p = str; *p; p++)
+	{
+		switch (*p)
+		{
+			case '"':
+				appendStringInfoString(buf, "\\\"");
+				break;
+			case '\\':
+				appendStringInfoString(buf, "\\\\");
+				break;
+			case '\b':
+				appendStringInfoString(buf, "\\b");
+				break;
+			case '\f':
+				appendStringInfoString(buf, "\\f");
+				break;
+			case '\n':
+				appendStringInfoString(buf, "\\n");
+				break;
+			case '\r':
+				appendStringInfoString(buf, "\\r");
+				break;
+			case '\t':
+				appendStringInfoString(buf, "\\t");
+				break;
+			default:
+				if ((unsigned char) *p < 0x20)
+					appendStringInfo(buf, "\\u%04x", (unsigned char) *p);
+				else
+					appendStringInfoChar(buf, *p);
+				break;
+		}
+	}
+	appendStringInfoChar(buf, '"');
+}
 
 /*
  * Log bucket data as JSON to PostgreSQL log - one log entry per query for scalability
@@ -32,14 +72,16 @@
 void
 pgsm_log_bucket_json(uint64 bucket_id)
 {
-	StringInfoData json;
-	int			ret;
-	MemoryContext old_context;
+	pgsmSharedState *pgsm;
+	PGSM_HASH_SEQ_STATUS hstat;
+	pgsmEntry  *entry;
 	struct timeval start_time,
 				end_time;
 	double		duration_seconds;
 	time_t		rotation_timestamp;
 	int			query_count = 0;
+	int			queries_exported = 0;
+	dsa_area   *query_dsa_area = NULL;
 
 	if (!pgsm_enable_json_log)
 		return;
@@ -48,133 +90,168 @@ pgsm_log_bucket_json(uint64 bucket_id)
 	gettimeofday(&start_time, NULL);
 	rotation_timestamp = time(NULL);
 
-	/* Initialize JSON output buffer */
-	initStringInfo(&json);
+	/* Get shared state and DSA area for query text */
+	pgsm = pgsm_get_ss();
+	query_dsa_area = get_dsa_area_for_query_text();
 
-	/* Try to execute a SQL query to get the bucket data */
-	old_context = CurrentMemoryContext;
-
-	PG_TRY();
+	/* First pass: count queries in this bucket */
+	pgsm_hash_seq_init(&hstat, get_pgsmHash(), true);
+	while ((entry = pgsm_hash_seq_next(&hstat)) != NULL)
 	{
-		/* Start a transaction for SQL execution */
-		if (SPI_connect() != SPI_OK_CONNECT)
+		if (entry->key.bucket_id == bucket_id)
+			query_count++;
+	}
+	pgsm_hash_seq_term(&hstat);
+
+	/* Log bucket rotation start with metadata */
+	elog(LOG, "[pg_stat_monitor] JSON export: {\"event\": \"bucket_rotation_start\", \"bucket_id\": %lu, \"timestamp\": %ld, \"query_count\": %d}",
+		 bucket_id, rotation_timestamp, query_count);
+
+	if (query_count > 0)
+	{
+		/* Second pass: export each query as JSON */
+		pgsm_hash_seq_init(&hstat, get_pgsmHash(), true);
+		while ((entry = pgsm_hash_seq_next(&hstat)) != NULL)
 		{
-			/* Failed to connect - likely in background context */
-			gettimeofday(&end_time, NULL);
-			duration_seconds = (end_time.tv_sec - start_time.tv_sec) +
-				(end_time.tv_usec - start_time.tv_usec) / 1000000.0;
-			elog(LOG, "[pg_stat_monitor] JSON export: {\"event\": \"bucket_rotation_error\", \"bucket_id\": %lu, \"timestamp\": %ld, \"duration_seconds\": %.3f, \"note\": \"SPI connection failed - background context\"}",
-				 bucket_id, rotation_timestamp, duration_seconds);
-			pfree(json.data);
-			return;
-		}
-
-		/* First get count of queries in this bucket */
-		appendStringInfo(&json, "SELECT COUNT(*) FROM pg_stat_monitor WHERE bucket = %lu", bucket_id);
-		ret = SPI_execute(json.data, true, 0);
-
-		if (ret == SPI_OK_SELECT && SPI_processed > 0)
-		{
-			bool		isnull;
-			Datum		count_datum = SPI_getbinval(SPI_tuptable->vals[0], SPI_tuptable->tupdesc, 1, &isnull);
-
-			if (!isnull)
-				query_count = DatumGetInt32(count_datum);
-		}
-
-		/* Log bucket rotation start with metadata */
-		elog(LOG, "[pg_stat_monitor] JSON export: {\"event\": \"bucket_rotation_start\", \"bucket_id\": %lu, \"timestamp\": %ld, \"query_count\": %d}",
-			 bucket_id, rotation_timestamp, query_count);
-
-		if (query_count > 0)
-		{
-			/* Reset and build query to get individual query records */
-			resetStringInfo(&json);
-			appendStringInfo(&json,
-							 "SELECT row_to_json(t) FROM ("
-							 "SELECT bucket, bucket_start_time, userid, username, dbid, datname, "
-							 "client_ip, pgsm_query_id, queryid, toplevel, top_queryid, query, "
-							 "comments, planid, query_plan, top_query, application_name, relations, "
-							 "cmd_type, cmd_type_text, elevel, sqlcode, message, calls, "
-							 "total_exec_time, min_exec_time, max_exec_time, mean_exec_time, "
-							 "stddev_exec_time, rows, shared_blks_hit, shared_blks_read, "
-							 "shared_blks_dirtied, shared_blks_written, local_blks_hit, "
-							 "local_blks_read, local_blks_dirtied, local_blks_written, "
-							 "temp_blks_read, temp_blks_written, shared_blk_read_time, "
-							 "shared_blk_write_time, local_blk_read_time, local_blk_write_time, "
-							 "temp_blk_read_time, temp_blk_write_time, resp_calls, cpu_user_time, "
-							 "cpu_sys_time, wal_records, wal_fpi, wal_bytes, bucket_done, plans, "
-							 "total_plan_time, min_plan_time, max_plan_time, mean_plan_time, "
-							 "stddev_plan_time, jit_functions, jit_generation_time, "
-							 "jit_inlining_count, jit_inlining_time, jit_optimization_count, "
-							 "jit_optimization_time, jit_emission_count, jit_emission_time "
-							 "FROM pg_stat_monitor WHERE bucket = %lu"
-							 ") t",
-							 bucket_id);
-
-			ret = SPI_execute(json.data, true, 0);
-
-			if (ret == SPI_OK_SELECT && SPI_processed > 0)
+			if (entry->key.bucket_id == bucket_id)
 			{
-				/* Log each query as a separate JSON entry */
-				for (uint64 i = 0; i < SPI_processed; i++)
+				StringInfoData json;
+				char	   *query_text = NULL;
+				char	   *username;
+				char	   *datname;
+				TimestampTz bucket_start_time = 0;
+
+				queries_exported++;
+
+				/* Get query text from DSA or local pointer */
+				if (DsaPointerIsValid(entry->query_text.query_pos) && query_dsa_area)
 				{
-					bool		isnull;
-					Datum		result_datum = SPI_getbinval(SPI_tuptable->vals[i], SPI_tuptable->tupdesc, 1, &isnull);
+					char	   *query_ptr = dsa_get_address(query_dsa_area, entry->query_text.query_pos);
 
-					if (!isnull)
-					{
-						StringInfoData log_msg;
-						char	   *query_json = TextDatumGetCString(result_datum);
-
-						/*
-						 * Build log message safely without format string
-						 * issues
-						 */
-						initStringInfo(&log_msg);
-						appendStringInfo(&log_msg,
-										 "[pg_stat_monitor] JSON export: {\"event\": \"bucket_query\", \"bucket_id\": %lu, \"timestamp\": %ld, \"query_index\": %lu, \"query_count\": %d, \"query\": ",
-										 bucket_id, rotation_timestamp, i + 1, query_count);
-						appendStringInfoString(&log_msg, query_json);
-						appendStringInfoChar(&log_msg, '}');
-
-						ereport(LOG, (errmsg_internal("%s", log_msg.data)));
-
-						pfree(log_msg.data);
-						if (query_json)
-							pfree(query_json);
-					}
+					query_text = pstrdup(query_ptr);
 				}
+				else if (entry->query_text.query_pointer)
+				{
+					query_text = pstrdup(entry->query_text.query_pointer);
+				}
+				else
+				{
+					query_text = pstrdup("Query text not available");
+				}
+
+				/* Get bucket start time if available */
+				if (bucket_id < pgsm_max_buckets)
+					bucket_start_time = pgsm->bucket_start_time[bucket_id];
+
+				/* Get username and database name */
+				username = entry->username[0] ? entry->username : "unknown";
+				datname = entry->datname[0] ? entry->datname : "unknown";
+
+				/* Build JSON for this query */
+				initStringInfo(&json);
+				appendStringInfo(&json,
+								 "[pg_stat_monitor] JSON export: {\"event\": \"bucket_query\", "
+								 "\"bucket_id\": %lu, "
+								 "\"timestamp\": %ld, "
+								 "\"query_index\": %d, "
+								 "\"query_count\": %d, "
+								 "\"query\": {",
+								 bucket_id, rotation_timestamp, queries_exported, query_count);
+
+				/* Basic identification fields */
+				appendStringInfo(&json,
+								 "\"bucket\": %lu, "
+								 "\"bucket_start_time\": %ld, "
+								 "\"userid\": %u, "
+								 "\"username\": \"%s\", "
+								 "\"dbid\": %u, "
+								 "\"datname\": \"%s\", "
+								 "\"queryid\": %lu, "
+								 "\"pgsm_query_id\": %lu, ",
+								 entry->key.bucket_id,
+								 (long) bucket_start_time,
+								 entry->key.userid,
+								 username,
+								 entry->key.dbid,
+								 datname,
+								 entry->key.queryid,
+								 entry->pgsm_query_id);
+
+				/* Query text - needs special escaping */
+				appendStringInfo(&json, "\"query\": ");
+				escape_json(&json, query_text);
+				appendStringInfo(&json, ", ");
+
+				/* Command type */
+				appendStringInfo(&json,
+								 "\"cmd_type\": %d, ",
+								 entry->counters.info.cmd_type);
+
+				/* Execution statistics */
+				appendStringInfo(&json,
+								 "\"calls\": %ld, "
+								 "\"total_exec_time\": %.3f, "
+								 "\"min_exec_time\": %.3f, "
+								 "\"max_exec_time\": %.3f, "
+								 "\"mean_exec_time\": %.3f, "
+								 "\"rows\": %ld, ",
+								 entry->counters.calls.calls,
+								 entry->counters.time.total_time,
+								 entry->counters.time.min_time,
+								 entry->counters.time.max_time,
+								 entry->counters.time.mean_time,
+								 entry->counters.calls.rows);
+
+				/* Block I/O statistics */
+				appendStringInfo(&json,
+								 "\"shared_blks_hit\": %ld, "
+								 "\"shared_blks_read\": %ld, "
+								 "\"shared_blks_dirtied\": %ld, "
+								 "\"shared_blks_written\": %ld, "
+								 "\"local_blks_hit\": %ld, "
+								 "\"local_blks_read\": %ld, "
+								 "\"local_blks_dirtied\": %ld, "
+								 "\"local_blks_written\": %ld, "
+								 "\"temp_blks_read\": %ld, "
+								 "\"temp_blks_written\": %ld, ",
+								 entry->counters.blocks.shared_blks_hit,
+								 entry->counters.blocks.shared_blks_read,
+								 entry->counters.blocks.shared_blks_dirtied,
+								 entry->counters.blocks.shared_blks_written,
+								 entry->counters.blocks.local_blks_hit,
+								 entry->counters.blocks.local_blks_read,
+								 entry->counters.blocks.local_blks_dirtied,
+								 entry->counters.blocks.local_blks_written,
+								 entry->counters.blocks.temp_blks_read,
+								 entry->counters.blocks.temp_blks_written);
+
+				/* WAL usage */
+				appendStringInfo(&json,
+								 "\"wal_records\": %ld, "
+								 "\"wal_fpi\": %ld, "
+								 "\"wal_bytes\": %lu",
+								 entry->counters.walusage.wal_records,
+								 entry->counters.walusage.wal_fpi,
+								 entry->counters.walusage.wal_bytes);
+
+				appendStringInfoString(&json, "}}");
+
+				/* Log this query */
+				ereport(LOG, (errmsg_internal("%s", json.data)));
+
+				pfree(json.data);
+				if (query_text)
+					pfree(query_text);
 			}
 		}
-
-		/* Calculate final duration and log bucket rotation end */
-		gettimeofday(&end_time, NULL);
-		duration_seconds = (end_time.tv_sec - start_time.tv_sec) +
-			(end_time.tv_usec - start_time.tv_usec) / 1000000.0;
-
-		elog(LOG, "[pg_stat_monitor] JSON export: {\"event\": \"bucket_rotation_end\", \"bucket_id\": %lu, \"timestamp\": %ld, \"duration_seconds\": %.3f, \"queries_exported\": %d}",
-			 bucket_id, rotation_timestamp, duration_seconds, query_count);
-
-		SPI_finish();
+		pgsm_hash_seq_term(&hstat);
 	}
-	PG_CATCH();
-	{
-		MemoryContextSwitchTo(old_context);
 
-		/*
-		 * SPI calls can fail in background processes, fall back to simple
-		 * logging
-		 */
-		gettimeofday(&end_time, NULL);
-		duration_seconds = (end_time.tv_sec - start_time.tv_sec) +
-			(end_time.tv_usec - start_time.tv_usec) / 1000000.0;
-		elog(LOG, "[pg_stat_monitor] JSON export: {\"event\": \"bucket_rotation_error\", \"bucket_id\": %lu, \"timestamp\": %ld, \"duration_seconds\": %.3f, \"note\": \"Export failed - not available in background context\"}",
-			 bucket_id, rotation_timestamp, duration_seconds);
+	/* Calculate final duration and log bucket rotation end */
+	gettimeofday(&end_time, NULL);
+	duration_seconds = (end_time.tv_sec - start_time.tv_sec) +
+		(end_time.tv_usec - start_time.tv_usec) / 1000000.0;
 
-		FlushErrorState();
-	}
-	PG_END_TRY();
-
-	pfree(json.data);
+	elog(LOG, "[pg_stat_monitor] JSON export: {\"event\": \"bucket_rotation_end\", \"bucket_id\": %lu, \"timestamp\": %ld, \"duration_seconds\": %.3f, \"queries_exported\": %d}",
+		 bucket_id, rotation_timestamp, duration_seconds, queries_exported);
 }

--- a/json_export.c
+++ b/json_export.c
@@ -3,6 +3,15 @@
  * json_export.c
  *	  JSON export functionality for pg_stat_monitor bucket data
  *
+ * Portions Copyright © 2018-2024, Percona LLC and/or its affiliates
+ *
+ * Portions Copyright (c) 1996-2024, PostgreSQL Global Development Group
+ *
+ * Portions Copyright (c) 1994, The Regents of the University of California
+ *
+ * IDENTIFICATION
+ *	  contrib/pg_stat_monitor/json_export.c
+ *
  *-------------------------------------------------------------------------
  */
 
@@ -24,12 +33,13 @@ void
 pgsm_log_bucket_json(uint64 bucket_id)
 {
 	StringInfoData json;
-	int	ret;
+	int			ret;
 	MemoryContext old_context;
-	struct timeval start_time, end_time;
-	double duration_seconds;
-	time_t rotation_timestamp;
-	int query_count = 0;
+	struct timeval start_time,
+				end_time;
+	double		duration_seconds;
+	time_t		rotation_timestamp;
+	int			query_count = 0;
 
 	if (!pgsm_enable_json_log)
 		return;
@@ -52,7 +62,7 @@ pgsm_log_bucket_json(uint64 bucket_id)
 			/* Failed to connect - likely in background context */
 			gettimeofday(&end_time, NULL);
 			duration_seconds = (end_time.tv_sec - start_time.tv_sec) +
-							  (end_time.tv_usec - start_time.tv_usec) / 1000000.0;
+				(end_time.tv_usec - start_time.tv_usec) / 1000000.0;
 			elog(LOG, "[pg_stat_monitor] JSON export: {\"event\": \"bucket_rotation_error\", \"bucket_id\": %lu, \"timestamp\": %ld, \"duration_seconds\": %.3f, \"note\": \"SPI connection failed - background context\"}",
 				 bucket_id, rotation_timestamp, duration_seconds);
 			pfree(json.data);
@@ -65,8 +75,9 @@ pgsm_log_bucket_json(uint64 bucket_id)
 
 		if (ret == SPI_OK_SELECT && SPI_processed > 0)
 		{
-			bool isnull;
-			Datum count_datum = SPI_getbinval(SPI_tuptable->vals[0], SPI_tuptable->tupdesc, 1, &isnull);
+			bool		isnull;
+			Datum		count_datum = SPI_getbinval(SPI_tuptable->vals[0], SPI_tuptable->tupdesc, 1, &isnull);
+
 			if (!isnull)
 				query_count = DatumGetInt32(count_datum);
 		}
@@ -80,26 +91,26 @@ pgsm_log_bucket_json(uint64 bucket_id)
 			/* Reset and build query to get individual query records */
 			resetStringInfo(&json);
 			appendStringInfo(&json,
-				"SELECT row_to_json(t) FROM ("
-				"SELECT bucket, bucket_start_time, userid, username, dbid, datname, "
-				"client_ip, pgsm_query_id, queryid, toplevel, top_queryid, query, "
-				"comments, planid, query_plan, top_query, application_name, relations, "
-				"cmd_type, cmd_type_text, elevel, sqlcode, message, calls, "
-				"total_exec_time, min_exec_time, max_exec_time, mean_exec_time, "
-				"stddev_exec_time, rows, shared_blks_hit, shared_blks_read, "
-				"shared_blks_dirtied, shared_blks_written, local_blks_hit, "
-				"local_blks_read, local_blks_dirtied, local_blks_written, "
-				"temp_blks_read, temp_blks_written, shared_blk_read_time, "
-				"shared_blk_write_time, local_blk_read_time, local_blk_write_time, "
-				"temp_blk_read_time, temp_blk_write_time, resp_calls, cpu_user_time, "
-				"cpu_sys_time, wal_records, wal_fpi, wal_bytes, bucket_done, plans, "
-				"total_plan_time, min_plan_time, max_plan_time, mean_plan_time, "
-				"stddev_plan_time, jit_functions, jit_generation_time, "
-				"jit_inlining_count, jit_inlining_time, jit_optimization_count, "
-				"jit_optimization_time, jit_emission_count, jit_emission_time "
-				"FROM pg_stat_monitor WHERE bucket = %lu"
-				") t",
-				bucket_id);
+							 "SELECT row_to_json(t) FROM ("
+							 "SELECT bucket, bucket_start_time, userid, username, dbid, datname, "
+							 "client_ip, pgsm_query_id, queryid, toplevel, top_queryid, query, "
+							 "comments, planid, query_plan, top_query, application_name, relations, "
+							 "cmd_type, cmd_type_text, elevel, sqlcode, message, calls, "
+							 "total_exec_time, min_exec_time, max_exec_time, mean_exec_time, "
+							 "stddev_exec_time, rows, shared_blks_hit, shared_blks_read, "
+							 "shared_blks_dirtied, shared_blks_written, local_blks_hit, "
+							 "local_blks_read, local_blks_dirtied, local_blks_written, "
+							 "temp_blks_read, temp_blks_written, shared_blk_read_time, "
+							 "shared_blk_write_time, local_blk_read_time, local_blk_write_time, "
+							 "temp_blk_read_time, temp_blk_write_time, resp_calls, cpu_user_time, "
+							 "cpu_sys_time, wal_records, wal_fpi, wal_bytes, bucket_done, plans, "
+							 "total_plan_time, min_plan_time, max_plan_time, mean_plan_time, "
+							 "stddev_plan_time, jit_functions, jit_generation_time, "
+							 "jit_inlining_count, jit_inlining_time, jit_optimization_count, "
+							 "jit_optimization_time, jit_emission_count, jit_emission_time "
+							 "FROM pg_stat_monitor WHERE bucket = %lu"
+							 ") t",
+							 bucket_id);
 
 			ret = SPI_execute(json.data, true, 0);
 
@@ -108,19 +119,22 @@ pgsm_log_bucket_json(uint64 bucket_id)
 				/* Log each query as a separate JSON entry */
 				for (uint64 i = 0; i < SPI_processed; i++)
 				{
-					bool isnull;
-					Datum result_datum = SPI_getbinval(SPI_tuptable->vals[i], SPI_tuptable->tupdesc, 1, &isnull);
+					bool		isnull;
+					Datum		result_datum = SPI_getbinval(SPI_tuptable->vals[i], SPI_tuptable->tupdesc, 1, &isnull);
 
 					if (!isnull)
 					{
 						StringInfoData log_msg;
-						char *query_json = TextDatumGetCString(result_datum);
+						char	   *query_json = TextDatumGetCString(result_datum);
 
-						/* Build log message safely without format string issues */
+						/*
+						 * Build log message safely without format string
+						 * issues
+						 */
 						initStringInfo(&log_msg);
 						appendStringInfo(&log_msg,
-							"[pg_stat_monitor] JSON export: {\"event\": \"bucket_query\", \"bucket_id\": %lu, \"timestamp\": %ld, \"query_index\": %lu, \"query_count\": %d, \"query\": ",
-							bucket_id, rotation_timestamp, i + 1, query_count);
+										 "[pg_stat_monitor] JSON export: {\"event\": \"bucket_query\", \"bucket_id\": %lu, \"timestamp\": %ld, \"query_index\": %lu, \"query_count\": %d, \"query\": ",
+										 bucket_id, rotation_timestamp, i + 1, query_count);
 						appendStringInfoString(&log_msg, query_json);
 						appendStringInfoChar(&log_msg, '}');
 
@@ -137,7 +151,7 @@ pgsm_log_bucket_json(uint64 bucket_id)
 		/* Calculate final duration and log bucket rotation end */
 		gettimeofday(&end_time, NULL);
 		duration_seconds = (end_time.tv_sec - start_time.tv_sec) +
-						  (end_time.tv_usec - start_time.tv_usec) / 1000000.0;
+			(end_time.tv_usec - start_time.tv_usec) / 1000000.0;
 
 		elog(LOG, "[pg_stat_monitor] JSON export: {\"event\": \"bucket_rotation_end\", \"bucket_id\": %lu, \"timestamp\": %ld, \"duration_seconds\": %.3f, \"queries_exported\": %d}",
 			 bucket_id, rotation_timestamp, duration_seconds, query_count);
@@ -148,10 +162,13 @@ pgsm_log_bucket_json(uint64 bucket_id)
 	{
 		MemoryContextSwitchTo(old_context);
 
-		/* SPI calls can fail in background processes, fall back to simple logging */
+		/*
+		 * SPI calls can fail in background processes, fall back to simple
+		 * logging
+		 */
 		gettimeofday(&end_time, NULL);
 		duration_seconds = (end_time.tv_sec - start_time.tv_sec) +
-						  (end_time.tv_usec - start_time.tv_usec) / 1000000.0;
+			(end_time.tv_usec - start_time.tv_usec) / 1000000.0;
 		elog(LOG, "[pg_stat_monitor] JSON export: {\"event\": \"bucket_rotation_error\", \"bucket_id\": %lu, \"timestamp\": %ld, \"duration_seconds\": %.3f, \"note\": \"Export failed - not available in background context\"}",
 			 bucket_id, rotation_timestamp, duration_seconds);
 

--- a/json_export.c
+++ b/json_export.c
@@ -136,7 +136,6 @@ void pgsm_log_bucket_json(uint64 bucket_id) {
 	pgsmEntry *entry;
 	struct timeval start_time, end_time;
 	double duration_seconds;
-	time_t rotation_timestamp;
 	int query_count = 0;
 	int queries_exported = 0;
 	dsa_area *query_dsa_area = NULL;
@@ -146,7 +145,6 @@ void pgsm_log_bucket_json(uint64 bucket_id) {
 
 	/* Record start time and timestamp for duration calculation */
 	gettimeofday(&start_time, NULL);
-	rotation_timestamp = time(NULL);
 
 	/* Get shared state and DSA area for query text */
 	pgsm = pgsm_get_ss();
@@ -163,9 +161,9 @@ void pgsm_log_bucket_json(uint64 bucket_id) {
 	/* Log bucket rotation start with metadata */
 	elog(
 	    LOG,
-	    "[pg_stat_monitor] JSON export: {\"event\": \"bucket_rotation_start\", "
-	    "\"bucket_id\": %lu, \"timestamp\": %ld, \"query_count\": %d}",
-	    bucket_id, rotation_timestamp, query_count);
+	    "[pg_stat_monitor] {\"event\":\"bucket_rotation_start\","
+	    "\"bucket_id\":%lu,\"query_count\":%d}",
+	    bucket_id, query_count);
 
 	if (query_count > 0) {
 		/* Second pass: export each query as comprehensive JSON */
@@ -219,20 +217,18 @@ void pgsm_log_bucket_json(uint64 bucket_id) {
 				 * structure */
 				initStringInfo(&json);
 				appendStringInfo(&json,
-				                 "[pg_stat_monitor] JSON export: {"
+				                 "[pg_stat_monitor] {"
 				                 "\"event\":\"bucket_query\","
 				                 "\"bucket_id\":%lu,"
-				                 "\"timestamp\":%ld,"
 				                 "\"query_index\":%d,"
 				                 "\"query_count\":%d,"
 
 				                 /* Basic identification */
 				                 "\"bucket\":%lu,"
-				                 "\"bucket_start_time\":%ld,"
+				                 "\"bucket_start_time\":\"%s\","
 				                 "\"userid\":%u,",
-				                 bucket_id, rotation_timestamp,
-				                 queries_exported, query_count,
-				                 entry->key.bucket_id, (long)bucket_start_time,
+				                 bucket_id, queries_exported, query_count,
+				                 entry->key.bucket_id, timestamptz_to_str(bucket_start_time),
 				                 entry->key.userid);
 
 				/* Handle username with proper escaping */
@@ -442,8 +438,7 @@ void pgsm_log_bucket_json(uint64 bucket_id) {
 	                   (end_time.tv_usec - start_time.tv_usec) / 1000000.0;
 
 	elog(LOG,
-	     "[pg_stat_monitor] JSON export: {\"event\": \"bucket_rotation_end\", "
-	     "\"bucket_id\": %lu, \"timestamp\": %ld, \"duration_seconds\": %.3f, "
-	     "\"queries_exported\": %d}",
-	     bucket_id, rotation_timestamp, duration_seconds, queries_exported);
+	     "[pg_stat_monitor] {\"event\":\"bucket_rotation_end\","
+	     "\"bucket_id\":%lu,\"duration_seconds\":%.3f,\"queries_exported\":%d}",
+	     bucket_id, duration_seconds, queries_exported);
 }

--- a/json_export.h
+++ b/json_export.h
@@ -1,0 +1,18 @@
+/*-------------------------------------------------------------------------
+ *
+ * json_export.h
+ *	  JSON export functionality for pg_stat_monitor bucket data
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef JSON_EXPORT_H
+#define JSON_EXPORT_H
+
+#include "postgres.h"
+#include "pg_stat_monitor.h"
+
+/* Function to log bucket data as JSON */
+extern void pgsm_log_bucket_json(uint64 bucket_id);
+
+#endif /* JSON_EXPORT_H */

--- a/json_export.h
+++ b/json_export.h
@@ -3,6 +3,15 @@
  * json_export.h
  *	  JSON export functionality for pg_stat_monitor bucket data
  *
+ * Portions Copyright © 2018-2024, Percona LLC and/or its affiliates
+ *
+ * Portions Copyright (c) 1996-2024, PostgreSQL Global Development Group
+ *
+ * Portions Copyright (c) 1994, The Regents of the University of California
+ *
+ * IDENTIFICATION
+ *	  contrib/pg_stat_monitor/json_export.h
+ *
  *-------------------------------------------------------------------------
  */
 
@@ -15,4 +24,4 @@
 /* Function to log bucket data as JSON */
 extern void pgsm_log_bucket_json(uint64 bucket_id);
 
-#endif /* JSON_EXPORT_H */
+#endif							/* JSON_EXPORT_H */

--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -2568,13 +2568,14 @@ get_next_wbucket(pgsmSharedState *pgsm)
 		/* Update bucket id and retrieve the previous one. */
 		prev_bucket_id = pg_atomic_exchange_u64(&pgsm->current_wbucket, new_bucket_id);
 
+		/* Log the previous bucket data as JSON if enabled */
+		if (pgsm_enable_json_log)
+			pgsm_log_bucket_json(prev_bucket_id);
+
 		pgsm_lock_aquire(pgsm, LW_EXCLUSIVE);
 		hash_entry_dealloc(new_bucket_id, prev_bucket_id, NULL);
 
 		pgsm_lock_release(pgsm);
-
-		/* Log the previous bucket data as JSON if enabled */
-		pgsm_log_bucket_json(prev_bucket_id);
 
 		/* Allign the value in prev_bucket_sec to the bucket start time */
 		tv.tv_sec = (tv.tv_sec) - (tv.tv_sec % pgsm_bucket_time);

--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -23,6 +23,7 @@
 #include "commands/dbcommands.h"
 #include "commands/explain.h"
 #include "pg_stat_monitor.h"
+#include "json_export.h"
 
  /*
   * Extension version number, for supporting older extension versions' objects
@@ -2572,6 +2573,9 @@ get_next_wbucket(pgsmSharedState *pgsm)
 
 		pgsm_lock_release(pgsm);
 
+		/* Log the previous bucket data as JSON if enabled */
+		pgsm_log_bucket_json(prev_bucket_id);
+
 		/* Allign the value in prev_bucket_sec to the bucket start time */
 		tv.tv_sec = (tv.tv_sec) - (tv.tv_sec % pgsm_bucket_time);
 
@@ -3962,3 +3966,5 @@ pgsm_lock_release(pgsmSharedState *pgsm)
 	disable_error_capture = false;
 	LWLockRelease(pgsm->lock);
 }
+
+

--- a/pg_stat_monitor.c
+++ b/pg_stat_monitor.c
@@ -3966,5 +3966,3 @@ pgsm_lock_release(pgsmSharedState *pgsm)
 	disable_error_capture = false;
 	LWLockRelease(pgsm->lock);
 }
-
-

--- a/pg_stat_monitor.h
+++ b/pg_stat_monitor.h
@@ -490,6 +490,7 @@ extern bool pgsm_track_utility;
 extern bool pgsm_track_application_names;
 extern bool pgsm_enable_pgsm_query_id;
 extern int	pgsm_track;
+extern bool pgsm_enable_json_log;
 
 #define DECLARE_HOOK(hook, ...) \
         static hook(__VA_ARGS__);
@@ -503,3 +504,4 @@ void		pgsm_hash_seq_init(PGSM_HASH_SEQ_STATUS * hstat, PGSM_HASH_TABLE * shared_
 void	   *pgsm_hash_seq_next(PGSM_HASH_SEQ_STATUS * hstat);
 void		pgsm_hash_seq_term(PGSM_HASH_SEQ_STATUS * hstat);
 void		pgsm_hash_delete_current(PGSM_HASH_SEQ_STATUS * hstat, PGSM_HASH_TABLE * shared_hash, void *key);
+

--- a/pg_stat_monitor.h
+++ b/pg_stat_monitor.h
@@ -504,4 +504,3 @@ void		pgsm_hash_seq_init(PGSM_HASH_SEQ_STATUS * hstat, PGSM_HASH_TABLE * shared_
 void	   *pgsm_hash_seq_next(PGSM_HASH_SEQ_STATUS * hstat);
 void		pgsm_hash_seq_term(PGSM_HASH_SEQ_STATUS * hstat);
 void		pgsm_hash_delete_current(PGSM_HASH_SEQ_STATUS * hstat, PGSM_HASH_TABLE * shared_hash, void *key);
-

--- a/regression/expected/guc.out
+++ b/regression/expected/guc.out
@@ -16,26 +16,27 @@ WHERE   name     LIKE     'pg_stat_monitor.%'
 ORDER
 BY      name
 COLLATE "C";
-                     name                     | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
-----------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_bucket_time             | 60      | s    | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
- pg_stat_monitor.pgsm_enable_overflow         | on      |      | postmaster | bool    | default |         |            |                | on       | on        | f
- pg_stat_monitor.pgsm_enable_pgsm_query_id    | on      |      | user       | bool    | default |         |            |                | on       | on        | f
- pg_stat_monitor.pgsm_enable_query_plan       | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_extract_comments        | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_histogram_buckets       | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
- pg_stat_monitor.pgsm_histogram_max           | 100000  | ms   | postmaster | real    | default | 10      | 5e+07      |                | 100000   | 100000    | f
- pg_stat_monitor.pgsm_histogram_min           | 1       | ms   | postmaster | real    | default | 0       | 5e+07      |                | 1        | 1         | f
- pg_stat_monitor.pgsm_max                     | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
- pg_stat_monitor.pgsm_max_buckets             | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
- pg_stat_monitor.pgsm_normalized_query        | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_overflow_target         | 1       |      | postmaster | integer | default | 0       | 1          |                | 1        | 1         | f
- pg_stat_monitor.pgsm_query_max_len           | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
- pg_stat_monitor.pgsm_query_shared_buffer     | 20      | MB   | postmaster | integer | default | 1       | 10000      |                | 20       | 20        | f
- pg_stat_monitor.pgsm_track                   | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
- pg_stat_monitor.pgsm_track_application_names | on      |      | user       | bool    | default |         |            |                | on       | on        | f
- pg_stat_monitor.pgsm_track_planning          | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_track_utility           | on      |      | user       | bool    | default |         |            |                | on       | on        | f
-(18 rows)
+                     name                     | setting | unit |  context   | vartype |       source       | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
+----------------------------------------------+---------+------+------------+---------+--------------------+---------+------------+----------------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_bucket_time             | 60      | s    | postmaster | integer | default            | 1       | 2147483647 |                | 60       | 60        | f
+ pg_stat_monitor.pgsm_enable_json_log         | off     |      | superuser  | bool    | default            |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_enable_overflow         | on      |      | postmaster | bool    | default            |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_pgsm_query_id    | on      |      | user       | bool    | default            |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_query_plan       | off     |      | user       | bool    | default            |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_extract_comments        | off     |      | user       | bool    | default            |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_histogram_buckets       | 20      |      | postmaster | integer | default            | 2       | 50         |                | 20       | 20        | f
+ pg_stat_monitor.pgsm_histogram_max           | 100000  | ms   | postmaster | real    | default            | 10      | 5e+07      |                | 100000   | 100000    | f
+ pg_stat_monitor.pgsm_histogram_min           | 1       | ms   | postmaster | real    | default            | 0       | 5e+07      |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_max                     | 10      | MB   | postmaster | integer | configuration file | 3       | 10240      |                | 256      | 10        | f
+ pg_stat_monitor.pgsm_max_buckets             | 2       |      | postmaster | integer | configuration file | 1       | 20000      |                | 10       | 2         | f
+ pg_stat_monitor.pgsm_normalized_query        | off     |      | user       | bool    | default            |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_overflow_target         | 1       |      | postmaster | integer | default            | 0       | 1          |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_query_max_len           | 1536    |      | postmaster | integer | configuration file | 1024    | 2147483647 |                | 2048     | 1536      | f
+ pg_stat_monitor.pgsm_query_shared_buffer     | 20      | MB   | postmaster | integer | default            | 3       | 10000      |                | 20       | 20        | f
+ pg_stat_monitor.pgsm_track                   | top     |      | user       | enum    | default            |         |            | {none,top,all} | top      | top       | f
+ pg_stat_monitor.pgsm_track_application_names | on      |      | user       | bool    | default            |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_track_planning          | off     |      | user       | bool    | default            |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_track_utility           | on      |      | user       | bool    | default            |         |            |                | on       | on        | f
+(19 rows)
 
 DROP EXTENSION pg_stat_monitor;

--- a/regression/expected/guc.out
+++ b/regression/expected/guc.out
@@ -16,27 +16,27 @@ WHERE   name     LIKE     'pg_stat_monitor.%'
 ORDER
 BY      name
 COLLATE "C";
-                     name                     | setting | unit |  context   | vartype |       source       | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
-----------------------------------------------+---------+------+------------+---------+--------------------+---------+------------+----------------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_bucket_time             | 60      | s    | postmaster | integer | default            | 1       | 2147483647 |                | 60       | 60        | f
- pg_stat_monitor.pgsm_enable_json_log         | off     |      | superuser  | bool    | default            |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_enable_overflow         | on      |      | postmaster | bool    | default            |         |            |                | on       | on        | f
- pg_stat_monitor.pgsm_enable_pgsm_query_id    | on      |      | user       | bool    | default            |         |            |                | on       | on        | f
- pg_stat_monitor.pgsm_enable_query_plan       | off     |      | user       | bool    | default            |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_extract_comments        | off     |      | user       | bool    | default            |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_histogram_buckets       | 20      |      | postmaster | integer | default            | 2       | 50         |                | 20       | 20        | f
- pg_stat_monitor.pgsm_histogram_max           | 100000  | ms   | postmaster | real    | default            | 10      | 5e+07      |                | 100000   | 100000    | f
- pg_stat_monitor.pgsm_histogram_min           | 1       | ms   | postmaster | real    | default            | 0       | 5e+07      |                | 1        | 1         | f
- pg_stat_monitor.pgsm_max                     | 10      | MB   | postmaster | integer | configuration file | 3       | 10240      |                | 256      | 10        | f
- pg_stat_monitor.pgsm_max_buckets             | 2       |      | postmaster | integer | configuration file | 1       | 20000      |                | 10       | 2         | f
- pg_stat_monitor.pgsm_normalized_query        | off     |      | user       | bool    | default            |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_overflow_target         | 1       |      | postmaster | integer | default            | 0       | 1          |                | 1        | 1         | f
- pg_stat_monitor.pgsm_query_max_len           | 1536    |      | postmaster | integer | configuration file | 1024    | 2147483647 |                | 2048     | 1536      | f
- pg_stat_monitor.pgsm_query_shared_buffer     | 20      | MB   | postmaster | integer | default            | 3       | 10000      |                | 20       | 20        | f
- pg_stat_monitor.pgsm_track                   | top     |      | user       | enum    | default            |         |            | {none,top,all} | top      | top       | f
- pg_stat_monitor.pgsm_track_application_names | on      |      | user       | bool    | default            |         |            |                | on       | on        | f
- pg_stat_monitor.pgsm_track_planning          | off     |      | user       | bool    | default            |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_track_utility           | on      |      | user       | bool    | default            |         |            |                | on       | on        | f
+                     name                     | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
+----------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_bucket_time             | 60      | s    | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
+ pg_stat_monitor.pgsm_enable_json_log         | off     |      | superuser  | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_enable_overflow         | on      |      | postmaster | bool    | default |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_pgsm_query_id    | on      |      | user       | bool    | default |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_query_plan       | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_extract_comments        | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_histogram_buckets       | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
+ pg_stat_monitor.pgsm_histogram_max           | 100000  | ms   | postmaster | real    | default | 10      | 5e+07      |                | 100000   | 100000    | f
+ pg_stat_monitor.pgsm_histogram_min           | 1       | ms   | postmaster | real    | default | 0       | 5e+07      |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_max                     | 256     | MB   | postmaster | integer | default | 3       | 10240      |                | 256      | 256       | f
+ pg_stat_monitor.pgsm_max_buckets             | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
+ pg_stat_monitor.pgsm_normalized_query        | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_overflow_target         | 1       |      | postmaster | integer | default | 0       | 1          |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_query_max_len           | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
+ pg_stat_monitor.pgsm_query_shared_buffer     | 20      | MB   | postmaster | integer | default | 3       | 10000      |                | 20       | 20        | f
+ pg_stat_monitor.pgsm_track                   | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
+ pg_stat_monitor.pgsm_track_application_names | on      |      | user       | bool    | default |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_track_planning          | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_track_utility           | on      |      | user       | bool    | default |         |            |                | on       | on        | f
 (19 rows)
 
 DROP EXTENSION pg_stat_monitor;

--- a/regression/expected/guc.out
+++ b/regression/expected/guc.out
@@ -32,7 +32,7 @@ COLLATE "C";
  pg_stat_monitor.pgsm_normalized_query        | off     |      | user       | bool    | default |         |            |                | off      | off       | f
  pg_stat_monitor.pgsm_overflow_target         | 1       |      | postmaster | integer | default | 0       | 1          |                | 1        | 1         | f
  pg_stat_monitor.pgsm_query_max_len           | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
- pg_stat_monitor.pgsm_query_shared_buffer     | 20      | MB   | postmaster | integer | default | 3       | 10000      |                | 20       | 20        | f
+ pg_stat_monitor.pgsm_query_shared_buffer     | 20      | MB   | postmaster | integer | default | 1       | 10000      |                | 20       | 20        | f
  pg_stat_monitor.pgsm_track                   | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
  pg_stat_monitor.pgsm_track_application_names | on      |      | user       | bool    | default |         |            |                | on       | on        | f
  pg_stat_monitor.pgsm_track_planning          | off     |      | user       | bool    | default |         |            |                | off      | off       | f

--- a/regression/expected/guc_1.out
+++ b/regression/expected/guc_1.out
@@ -16,27 +16,27 @@ WHERE   name     LIKE     'pg_stat_monitor.%'
 ORDER
 BY      name
 COLLATE "C";
-                     name                     | setting | unit |  context   | vartype |       source       | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
-----------------------------------------------+---------+------+------------+---------+--------------------+---------+------------+----------------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_bucket_time             | 60      | s    | postmaster | integer | default            | 1       | 2147483647 |                | 60       | 60        | f
- pg_stat_monitor.pgsm_enable_json_log         | on      |      | superuser  | bool    | default            |         |            |                | on       | on        | f
- pg_stat_monitor.pgsm_enable_overflow         | on      |      | postmaster | bool    | default            |         |            |                | on       | on        | f
- pg_stat_monitor.pgsm_enable_pgsm_query_id    | on      |      | user       | bool    | default            |         |            |                | on       | on        | f
- pg_stat_monitor.pgsm_enable_query_plan       | off     |      | user       | bool    | default            |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_extract_comments        | off     |      | user       | bool    | default            |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_histogram_buckets       | 20      |      | postmaster | integer | default            | 2       | 50         |                | 20       | 20        | f
- pg_stat_monitor.pgsm_histogram_max           | 100000  | ms   | postmaster | real    | default            | 10      | 5e+07      |                | 100000   | 100000    | f
- pg_stat_monitor.pgsm_histogram_min           | 1       | ms   | postmaster | real    | default            | 0       | 5e+07      |                | 1        | 1         | f
- pg_stat_monitor.pgsm_max                     | 10      | MB   | postmaster | integer | configuration file | 3       | 10240      |                | 3        | 10        | f
- pg_stat_monitor.pgsm_max_buckets             | 2       |      | postmaster | integer | configuration file | 1       | 20000      |                | 2        | 2         | f
- pg_stat_monitor.pgsm_normalized_query        | off     |      | user       | bool    | default            |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_overflow_target         | 1       |      | postmaster | integer | default            | 0       | 1          |                | 1        | 1         | f
- pg_stat_monitor.pgsm_query_max_len           | 1536    |      | postmaster | integer | configuration file | 1024    | 2147483647 |                | 2048     | 1536      | f
- pg_stat_monitor.pgsm_query_shared_buffer     | 3       | MB   | postmaster | integer | default            | 3       | 10000      |                | 3        | 3         | f
- pg_stat_monitor.pgsm_track                   | top     |      | user       | enum    | default            |         |            | {none,top,all} | top      | top       | f
- pg_stat_monitor.pgsm_track_application_names | on      |      | user       | bool    | default            |         |            |                | on       | on        | f
- pg_stat_monitor.pgsm_track_planning          | off     |      | user       | bool    | default            |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_track_utility           | on      |      | user       | bool    | default            |         |            |                | on       | on        | f
+                     name                     | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart
+----------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_bucket_time             | 60      | s    | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
+ pg_stat_monitor.pgsm_enable_json_log         | off     |      | superuser  | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_enable_overflow         | on      |      | postmaster | bool    | default |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_pgsm_query_id    | on      |      | user       | bool    | default |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_query_plan       | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_extract_comments        | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_histogram_buckets       | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
+ pg_stat_monitor.pgsm_histogram_max           | 100000  | ms   | postmaster | real    | default | 10      | 5e+07      |                | 100000   | 100000    | f
+ pg_stat_monitor.pgsm_histogram_min           | 1       | ms   | postmaster | real    | default | 0       | 5e+07      |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_max                     | 256     | MB   | postmaster | integer | default | 3       | 10240      |                | 256      | 256       | f
+ pg_stat_monitor.pgsm_max_buckets             | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
+ pg_stat_monitor.pgsm_normalized_query        | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_overflow_target         | 1       |      | postmaster | integer | default | 0       | 1          |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_query_max_len           | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
+ pg_stat_monitor.pgsm_query_shared_buffer     | 20      | MB   | postmaster | integer | default | 1       | 10000      |                | 20       | 20        | f
+ pg_stat_monitor.pgsm_track                   | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
+ pg_stat_monitor.pgsm_track_application_names | on      |      | user       | bool    | default |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_track_planning          | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_track_utility           | on      |      | user       | bool    | default |         |            |                | on       | on        | f
 (19 rows)
 
 DROP EXTENSION pg_stat_monitor;

--- a/regression/expected/guc_1.out
+++ b/regression/expected/guc_1.out
@@ -16,27 +16,27 @@ WHERE   name     LIKE     'pg_stat_monitor.%'
 ORDER
 BY      name
 COLLATE "C";
-                     name                     | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart
-----------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_bucket_time             | 60      | s    | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
- pg_stat_monitor.pgsm_enable_json_log         | off     |      | superuser  | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_enable_overflow         | on      |      | postmaster | bool    | default |         |            |                | on       | on        | f
- pg_stat_monitor.pgsm_enable_pgsm_query_id    | on      |      | user       | bool    | default |         |            |                | on       | on        | f
- pg_stat_monitor.pgsm_enable_query_plan       | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_extract_comments        | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_histogram_buckets       | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
- pg_stat_monitor.pgsm_histogram_max           | 100000  | ms   | postmaster | real    | default | 10      | 5e+07      |                | 100000   | 100000    | f
- pg_stat_monitor.pgsm_histogram_min           | 1       | ms   | postmaster | real    | default | 0       | 5e+07      |                | 1        | 1         | f
- pg_stat_monitor.pgsm_max                     | 256     | MB   | postmaster | integer | default | 3       | 10240      |                | 256      | 256       | f
- pg_stat_monitor.pgsm_max_buckets             | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
- pg_stat_monitor.pgsm_normalized_query        | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_overflow_target         | 1       |      | postmaster | integer | default | 0       | 1          |                | 1        | 1         | f
- pg_stat_monitor.pgsm_query_max_len           | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
- pg_stat_monitor.pgsm_query_shared_buffer     | 20      | MB   | postmaster | integer | default | 1       | 10000      |                | 20       | 20        | f
- pg_stat_monitor.pgsm_track                   | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
- pg_stat_monitor.pgsm_track_application_names | on      |      | user       | bool    | default |         |            |                | on       | on        | f
- pg_stat_monitor.pgsm_track_planning          | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_track_utility           | on      |      | user       | bool    | default |         |            |                | on       | on        | f
+                     name                     | setting | unit |  context   | vartype |       source       | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
+----------------------------------------------+---------+------+------------+---------+--------------------+---------+------------+----------------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_bucket_time             | 60      | s    | postmaster | integer | default            | 1       | 2147483647 |                | 60       | 60        | f
+ pg_stat_monitor.pgsm_enable_json_log         | off     |      | superuser  | bool    | default            |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_enable_overflow         | on      |      | postmaster | bool    | default            |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_pgsm_query_id    | on      |      | user       | bool    | default            |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_query_plan       | off     |      | user       | bool    | default            |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_extract_comments        | off     |      | user       | bool    | default            |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_histogram_buckets       | 20      |      | postmaster | integer | default            | 2       | 50         |                | 20       | 20        | f
+ pg_stat_monitor.pgsm_histogram_max           | 100000  | ms   | postmaster | real    | default            | 10      | 5e+07      |                | 100000   | 100000    | f
+ pg_stat_monitor.pgsm_histogram_min           | 1       | ms   | postmaster | real    | default            | 0       | 5e+07      |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_max                     | 10      | MB   | postmaster | integer | configuration file | 3       | 10240      |                | 256      | 10        | f
+ pg_stat_monitor.pgsm_max_buckets             | 2       |      | postmaster | integer | configuration file | 1       | 20000      |                | 10       | 2         | f
+ pg_stat_monitor.pgsm_normalized_query        | off     |      | user       | bool    | default            |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_overflow_target         | 1       |      | postmaster | integer | default            | 0       | 1          |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_query_max_len           | 1536    |      | postmaster | integer | configuration file | 1024    | 2147483647 |                | 2048     | 1536      | f
+ pg_stat_monitor.pgsm_query_shared_buffer     | 20      | MB   | postmaster | integer | default            | 3       | 10000      |                | 20       | 20        | f
+ pg_stat_monitor.pgsm_track                   | top     |      | user       | enum    | default            |         |            | {none,top,all} | top      | top       | f
+ pg_stat_monitor.pgsm_track_application_names | on      |      | user       | bool    | default            |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_track_planning          | off     |      | user       | bool    | default            |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_track_utility           | on      |      | user       | bool    | default            |         |            |                | on       | on        | f
 (19 rows)
 
 DROP EXTENSION pg_stat_monitor;

--- a/regression/expected/guc_1.out
+++ b/regression/expected/guc_1.out
@@ -16,25 +16,27 @@ WHERE   name     LIKE     'pg_stat_monitor.%'
 ORDER
 BY      name
 COLLATE "C";
-                     name                     | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
-----------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_bucket_time             | 60      | s    | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
- pg_stat_monitor.pgsm_enable_overflow         | on      |      | postmaster | bool    | default |         |            |                | on       | on        | f
- pg_stat_monitor.pgsm_enable_pgsm_query_id    | on      |      | user       | bool    | default |         |            |                | on       | on        | f
- pg_stat_monitor.pgsm_enable_query_plan       | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_extract_comments        | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_histogram_buckets       | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
- pg_stat_monitor.pgsm_histogram_max           | 100000  | ms   | postmaster | real    | default | 10      | 5e+07      |                | 100000   | 100000    | f
- pg_stat_monitor.pgsm_histogram_min           | 1       | ms   | postmaster | real    | default | 0       | 5e+07      |                | 1        | 1         | f
- pg_stat_monitor.pgsm_max                     | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
- pg_stat_monitor.pgsm_max_buckets             | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
- pg_stat_monitor.pgsm_normalized_query        | off     |      | user       | bool    | default |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_overflow_target         | 1       |      | postmaster | integer | default | 0       | 1          |                | 1        | 1         | f
- pg_stat_monitor.pgsm_query_max_len           | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
- pg_stat_monitor.pgsm_query_shared_buffer     | 20      | MB   | postmaster | integer | default | 1       | 10000      |                | 20       | 20        | f
- pg_stat_monitor.pgsm_track                   | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
- pg_stat_monitor.pgsm_track_application_names | on      |      | user       | bool    | default |         |            |                | on       | on        | f
- pg_stat_monitor.pgsm_track_utility           | on      |      | user       | bool    | default |         |            |                | on       | on        | f
-(17 rows)
+                     name                     | setting | unit |  context   | vartype |       source       | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
+----------------------------------------------+---------+------+------------+---------+--------------------+---------+------------+----------------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_bucket_time             | 60      | s    | postmaster | integer | default            | 1       | 2147483647 |                | 60       | 60        | f
+ pg_stat_monitor.pgsm_enable_json_log         | on      |      | superuser  | bool    | default            |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_overflow         | on      |      | postmaster | bool    | default            |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_pgsm_query_id    | on      |      | user       | bool    | default            |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_query_plan       | off     |      | user       | bool    | default            |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_extract_comments        | off     |      | user       | bool    | default            |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_histogram_buckets       | 20      |      | postmaster | integer | default            | 2       | 50         |                | 20       | 20        | f
+ pg_stat_monitor.pgsm_histogram_max           | 100000  | ms   | postmaster | real    | default            | 10      | 5e+07      |                | 100000   | 100000    | f
+ pg_stat_monitor.pgsm_histogram_min           | 1       | ms   | postmaster | real    | default            | 0       | 5e+07      |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_max                     | 10      | MB   | postmaster | integer | configuration file | 3       | 10240      |                | 3        | 10        | f
+ pg_stat_monitor.pgsm_max_buckets             | 2       |      | postmaster | integer | configuration file | 1       | 20000      |                | 2        | 2         | f
+ pg_stat_monitor.pgsm_normalized_query        | off     |      | user       | bool    | default            |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_overflow_target         | 1       |      | postmaster | integer | default            | 0       | 1          |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_query_max_len           | 1536    |      | postmaster | integer | configuration file | 1024    | 2147483647 |                | 2048     | 1536      | f
+ pg_stat_monitor.pgsm_query_shared_buffer     | 3       | MB   | postmaster | integer | default            | 3       | 10000      |                | 3        | 3         | f
+ pg_stat_monitor.pgsm_track                   | top     |      | user       | enum    | default            |         |            | {none,top,all} | top      | top       | f
+ pg_stat_monitor.pgsm_track_application_names | on      |      | user       | bool    | default            |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_track_planning          | off     |      | user       | bool    | default            |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_track_utility           | on      |      | user       | bool    | default            |         |            |                | on       | on        | f
+(19 rows)
 
 DROP EXTENSION pg_stat_monitor;

--- a/regression/expected/guc_1.out
+++ b/regression/expected/guc_1.out
@@ -16,27 +16,25 @@ WHERE   name     LIKE     'pg_stat_monitor.%'
 ORDER
 BY      name
 COLLATE "C";
-                     name                     | setting | unit |  context   | vartype |       source       | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
-----------------------------------------------+---------+------+------------+---------+--------------------+---------+------------+----------------+----------+-----------+-----------------
- pg_stat_monitor.pgsm_bucket_time             | 60      | s    | postmaster | integer | default            | 1       | 2147483647 |                | 60       | 60        | f
- pg_stat_monitor.pgsm_enable_json_log         | off     |      | superuser  | bool    | default            |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_enable_overflow         | on      |      | postmaster | bool    | default            |         |            |                | on       | on        | f
- pg_stat_monitor.pgsm_enable_pgsm_query_id    | on      |      | user       | bool    | default            |         |            |                | on       | on        | f
- pg_stat_monitor.pgsm_enable_query_plan       | off     |      | user       | bool    | default            |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_extract_comments        | off     |      | user       | bool    | default            |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_histogram_buckets       | 20      |      | postmaster | integer | default            | 2       | 50         |                | 20       | 20        | f
- pg_stat_monitor.pgsm_histogram_max           | 100000  | ms   | postmaster | real    | default            | 10      | 5e+07      |                | 100000   | 100000    | f
- pg_stat_monitor.pgsm_histogram_min           | 1       | ms   | postmaster | real    | default            | 0       | 5e+07      |                | 1        | 1         | f
- pg_stat_monitor.pgsm_max                     | 10      | MB   | postmaster | integer | configuration file | 3       | 10240      |                | 256      | 10        | f
- pg_stat_monitor.pgsm_max_buckets             | 2       |      | postmaster | integer | configuration file | 1       | 20000      |                | 10       | 2         | f
- pg_stat_monitor.pgsm_normalized_query        | off     |      | user       | bool    | default            |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_overflow_target         | 1       |      | postmaster | integer | default            | 0       | 1          |                | 1        | 1         | f
- pg_stat_monitor.pgsm_query_max_len           | 1536    |      | postmaster | integer | configuration file | 1024    | 2147483647 |                | 2048     | 1536      | f
- pg_stat_monitor.pgsm_query_shared_buffer     | 20      | MB   | postmaster | integer | default            | 3       | 10000      |                | 20       | 20        | f
- pg_stat_monitor.pgsm_track                   | top     |      | user       | enum    | default            |         |            | {none,top,all} | top      | top       | f
- pg_stat_monitor.pgsm_track_application_names | on      |      | user       | bool    | default            |         |            |                | on       | on        | f
- pg_stat_monitor.pgsm_track_planning          | off     |      | user       | bool    | default            |         |            |                | off      | off       | f
- pg_stat_monitor.pgsm_track_utility           | on      |      | user       | bool    | default            |         |            |                | on       | on        | f
-(19 rows)
+                     name                     | setting | unit |  context   | vartype | source  | min_val |  max_val   |    enumvals    | boot_val | reset_val | pending_restart 
+----------------------------------------------+---------+------+------------+---------+---------+---------+------------+----------------+----------+-----------+-----------------
+ pg_stat_monitor.pgsm_bucket_time             | 60      | s    | postmaster | integer | default | 1       | 2147483647 |                | 60       | 60        | f
+ pg_stat_monitor.pgsm_enable_overflow         | on      |      | postmaster | bool    | default |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_pgsm_query_id    | on      |      | user       | bool    | default |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_enable_query_plan       | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_extract_comments        | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_histogram_buckets       | 20      |      | postmaster | integer | default | 2       | 50         |                | 20       | 20        | f
+ pg_stat_monitor.pgsm_histogram_max           | 100000  | ms   | postmaster | real    | default | 10      | 5e+07      |                | 100000   | 100000    | f
+ pg_stat_monitor.pgsm_histogram_min           | 1       | ms   | postmaster | real    | default | 0       | 5e+07      |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_max                     | 256     | MB   | postmaster | integer | default | 10      | 10240      |                | 256      | 256       | f
+ pg_stat_monitor.pgsm_max_buckets             | 10      |      | postmaster | integer | default | 1       | 20000      |                | 10       | 10        | f
+ pg_stat_monitor.pgsm_normalized_query        | off     |      | user       | bool    | default |         |            |                | off      | off       | f
+ pg_stat_monitor.pgsm_overflow_target         | 1       |      | postmaster | integer | default | 0       | 1          |                | 1        | 1         | f
+ pg_stat_monitor.pgsm_query_max_len           | 2048    |      | postmaster | integer | default | 1024    | 2147483647 |                | 2048     | 2048      | f
+ pg_stat_monitor.pgsm_query_shared_buffer     | 20      | MB   | postmaster | integer | default | 1       | 10000      |                | 20       | 20        | f
+ pg_stat_monitor.pgsm_track                   | top     |      | user       | enum    | default |         |            | {none,top,all} | top      | top       | f
+ pg_stat_monitor.pgsm_track_application_names | on      |      | user       | bool    | default |         |            |                | on       | on        | f
+ pg_stat_monitor.pgsm_track_utility           | on      |      | user       | bool    | default |         |            |                | on       | on        | f
+(17 rows)
 
 DROP EXTENSION pg_stat_monitor;


### PR DESCRIPTION
POC with < 5mb memory footprint that logs out the data on each bucket rotation
The new logic is all in 1 new file so maintaining as a fork would be low-lift
Again, just a POC. Not a preferred solution